### PR TITLE
Fresh compile fix

### DIFF
--- a/compiler/pre-compiler/class.PBP.php
+++ b/compiler/pre-compiler/class.PBP.php
@@ -577,6 +577,7 @@ EOD;
 	}
 	
 	public function clean_directories() {
+		if (!file_exists('gamemodes/.build')) return;
 		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator('gamemodes/.build'), RecursiveIteratorIterator::CHILD_FIRST);
 		
 		foreach ($iterator as $path) {


### PR DESCRIPTION
Hallo,
compile script crashes when .build directory doesn't exist. I don't know, maybe it's better to create dir on first run. However, check before cleanup also solves compile problem.
